### PR TITLE
Support repeated embedded messages

### DIFF
--- a/lib/beefcake/buffer/base.rb
+++ b/lib/beefcake/buffer/base.rb
@@ -3,14 +3,14 @@ module Beefcake
   class Buffer
 
     MinUint32 =  0
-    MaxUint32 =  (1 << 32)-1
-    MinInt32  = -(1 << 31)
-    MaxInt32  =  (1 << 31)-1
+    MaxUint32 =  (1<<32)-1
+    MinInt32  = -(1<<31)
+    MaxInt32  =  (1<<31)-1
 
     MinUint64 =  0
-    MaxUint64 =  (1 << 64)-1
-    MinInt64  = -(1 << 63)
-    MaxInt64  =  (1 << 63)-1
+    MaxUint64 =  (1<<64)-1
+    MinInt64  = -(1<<63)
+    MaxInt64  =  (1<<63)-1
 
     def self.wire_for(type)
       case type

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -290,8 +290,9 @@ class MessageTest < Test::Unit::TestCase
   end
 
   def test_decode_repeated_nested
-    msg = RepeatedNestedMessage.new(:simple => [SimpleMessage.new(:a => 1),
-                                                SimpleMessage.new(:b => "hello")]).encode
+    msg = RepeatedNestedMessage.new(:simple =>
+                                    [SimpleMessage.new(:a => 1),
+                                     SimpleMessage.new(:b => "hello")]).encode
     got = RepeatedNestedMessage.decode(msg)
     assert_equal 2, got.simple.size
     assert_equal 1, got.simple[0].a


### PR DESCRIPTION
Embedded message fields weren't being properly decoded when they were repeated. This fixes that and some wonkiness around Module and Class in case statements.
