### PR TITLE
Buffer can get messed up by appends of other encoded strings.

### DIFF
--- a/lib/beefcake/buffer/base.rb
+++ b/lib/beefcake/buffer/base.rb
@@ -70,6 +70,10 @@ module Beefcake
       def buf=(buf)
         @buf = buf.force_encoding('BINARY')
       end
+
+      def buf
+        @buf.force_encoding('BINARY')
+      end
     end
 
     def length


### PR DESCRIPTION
Force encoding when you get the buffer out.  
