### PR TITLE
make append_bytes correctly handle Fixnum

### DIFF
--- a/lib/beefcake/buffer/encode.rb
+++ b/lib/beefcake/buffer/encode.rb
@@ -108,7 +108,12 @@ module Beefcake
       append_uint64(s.length)
       self << s
     end
-    alias :append_bytes :append_string
+
+    def append_bytes(b)
+      b = b.to_s
+      append_uint64(b.length)
+      self << b
+    end
 
   end
 

--- a/test/buffer_encode_test.rb
+++ b/test/buffer_encode_test.rb
@@ -217,6 +217,10 @@ class BufferEncodeTest < Test::Unit::TestCase
   def test_append_bytes
     @buf.append_bytes("testing")
     assert_equal "\007testing", @buf.to_s
+
+    @buf.buf = ""
+    @buf.append_bytes(380253)
+    assert_equal "\006380253", @buf.to_s
   end
 
 end


### PR DESCRIPTION
Hey there,

I ran into some trouble using ripple (https://github.com/seancribbs/ripple) when passing a Fixnum to the model's find method:

```
irb> Foo.find 123

TypeError: can't convert Fixnum into String
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake/buffer/base.rb:80:in `<<'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake/buffer/base.rb:80:in `<<'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake/buffer/encode.rb:115:in `append_bytes'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake/buffer/encode.rb:13:in `__send__'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake/buffer/encode.rb:13:in `append'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:102:in `encode!'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:90:in `each'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:90:in `encode!'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:79:in `encode'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:72:in `each'
    from /home/vagrant/sandbox/rails-app/gems/gems/beefcake-0.3.7/lib/beefcake.rb:72:in `encode'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client/beefcake_protobuffs_backend.rb:122:in `write_protobuff'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client/beefcake_protobuffs_backend.rb:37:in `fetch_object'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:275:in `get_object'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:428:in `recover_from'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client/pool.rb:126:in `take'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:426:in `recover_from'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:374:in `protobuffs'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:128:in `backend'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/client.rb:274:in `get_object'
    from /home/vagrant/sandbox/rails-app/gems/gems/riak-client-1.0.0/lib/riak/bucket.rb:88:in `get'
    from /home/vagrant/sandbox/rails-app/gems/gems/ripple-1.0.0.beta/lib/ripple/document/finders.rb:113:in `find_one'
    from /home/vagrant/sandbox/rails-app/gems/gems/ripple-1.0.0.beta/lib/ripple/document/finders.rb:55:in `find'
```

This only errors out when using the beefcake backend but works fine over http.  The problem is that the ripple/riak-client code passes the Fixnum to `Beefcake::Buffer#append`, mapping to `#append_bytes` which expects the value to respond to `#length`. If you think the transformation from Fixnum to string should be done elsewhere (perhaps in Riak::Client ?) I'm open to suggestions.

I've attached a test to reproduce the error and a fix that works for me.  I've made the assumption that `#append_bytes` should be able to handle more than just strings.

Feedback welcome! 

Cheers,

Erick
