### PR TITLE
always use BINARY encoding of strings internally

### DIFF
--- a/lib/beefcake/buffer/base.rb
+++ b/lib/beefcake/buffer/base.rb
@@ -63,7 +63,11 @@ module Beefcake
     end
 
     def initialize(buf="")
-      self.buf = buf
+      if buf.respond_to?(:force_encoding)
+        self.buf = buf.force_encoding("BINARY")
+      else
+        self.buf = buf
+      end
     end
 
     if ''.respond_to?(:force_encoding)

--- a/lib/beefcake/buffer/encode.rb
+++ b/lib/beefcake/buffer/encode.rb
@@ -106,7 +106,11 @@ module Beefcake
 
     def append_string(s)
       append_uint64(s.length)
-      self << s
+      if s.respond_to?(:force_encoding)
+        self << s.force_encoding("BINARY")
+      else
+        self << s
+      end
     end
     alias :append_bytes :append_string
 


### PR DESCRIPTION
I was observing issues when using UTF-8 strings as inputs where
messages wouldn't roundtrip correctly from Message.decode(msg.encode.to_s). These
changes ensures all strings are dealt with using BINARY encoding which
solves my problems.

I will admit to  not being fully aware of what the protobuf standard says about encodings and how to treat strings. As time permits I'll try to look at how the reference implementations deal with encodings.

All tests still pass.
