### PR TITLE
Support top-level enums

### DIFF
--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -262,12 +262,13 @@ module Beefcake
       puts
 
       ns!(ns) do
-        Array(file.message_type).each do |mt|
-          message!(file.package, mt)
-        end
-
         Array(file.enum_type).each do |et|
           enum!(et)
+        end
+        puts
+
+        Array(file.message_type).each do |mt|
+          message!(file.package, mt)
         end
       end
     end


### PR DESCRIPTION
This PR adds generator support for top-level `enum`s (ie. declared outside a `message`).

It also removes the apparently unused `file!` method -- please let me know if this has to stay for any reason.
