### PR TITLE
Add Travis CI integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - jruby-18mode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+PATH
+  remote: .
+  specs:
+    beefcake (0.3.8)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rake (10.1.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  beefcake!
+  rake (= 10.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,12 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
+end
+
+task :default => :test

--- a/beefcake.gemspec
+++ b/beefcake.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_development_dependency('rake', '10.1.0')
 end

--- a/test/buffer_decode_test.rb
+++ b/test/buffer_decode_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'beefcake/buffer'
 
 class BufferDecodeTest < Test::Unit::TestCase

--- a/test/buffer_encode_test.rb
+++ b/test/buffer_encode_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'beefcake/buffer/encode'
 
 class BufferEncodeTest < Test::Unit::TestCase

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'beefcake/buffer'
 
 class BufferTest < Test::Unit::TestCase

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'beefcake/generator'
 
 class GeneratorTest < Test::Unit::TestCase

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'beefcake'
 
 class NumericsMessage


### PR DESCRIPTION
This commit introduces nascent Travis CI integration for Beefcake,
which will make the triage of antique pull requests far easier and
more reliable.

Due to how antique some of the code and the tooling around it is, I
have opted to use a direct makefile (.travis.makefile) to drive the
tests instead of using Travis with its implicit environmental
assumption.

Code Reviewer (will be deleted upon +1): Please note explicit
sections with REVIEWER heading to indicate problematic items.
