### PR TITLE
Update testing documentation and add build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,13 @@ Source:
     $ git clone git://github.com/bmizerany/beefcake
 
 ## Testing:
+    $ rake test
 
-    $ gem install turn
-    $ cd /path/to/beefcake
-    $ turn
+Beefcake conducts continuous integration on [Travis CI](http://travis-ci.org).
+The current build status for HEAD is [![Build Status](https://travis-ci.org/protobuf-ruby/beefcake.png)](https://travis-ci.org/protobuf-ruby/beefcake).
+
+All pull requests automatically trigger a build request.  Please ensure that
+tests succeed.
 
 ## VMs:
 


### PR DESCRIPTION
Per working with @grobie, we decided to update the test process to use
the standard Rake-based workflow.  This commit updates the
documentation accordingly and adds continuous build status.
