### PR TITLE
Return nil if no varient encoded messages can be read

### DIFF
--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -200,6 +200,8 @@ module Beefcake
           buf = Buffer.new(buf)
         end
 
+        return if buf.length == 0
+
         n = buf.read_int64
         tmp = Buffer.new(buf.read(n))
 

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -180,6 +180,10 @@ class MessageTest < Test::Unit::TestCase
     end
   end
 
+  def test_empty_buffer_delimited_read
+    assert_equal SimpleMessage.read_delimited(""), nil
+  end
+
   def test_encode_enum
     buf = Beefcake::Buffer.new
     buf.append(:int32, 2, 1)


### PR DESCRIPTION
Instead of raising an exception of an underlaying function call, simply
return nil.

@matttproud 
