### PR TITLE
Remove unnecessary newline

### DIFF
--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -209,7 +209,6 @@ module Beefcake
       end
 
       puts "end"
-      puts
     end
 
     def enum!(et)


### PR DESCRIPTION
This change replaces the two newlines between message class definitions
with a single one, which is more common in ruby code guidelines.

@matttproud 
