### PR TITLE
Use hash lookup instead of case statements

### DIFF
--- a/lib/beefcake/buffer/base.rb
+++ b/lib/beefcake/buffer/base.rb
@@ -12,22 +12,33 @@ module Beefcake
     MinInt64  = -(1<<63)
     MaxInt64  =  (1<<63)-1
 
+    WIRES = {
+      :int32    => 0,
+      :uint32   => 0,
+      :sint32   => 0,
+      :int64    => 0,
+      :uint64   => 0,
+      :sint64   => 0,
+      :bool     => 0,
+      :fixed64  => 1,
+      :sfixed64 => 1,
+      :double   => 1,
+      :string   => 2,
+      :bytes    => 2,
+      :fixed32  => 5,
+      :sfixed32 => 5,
+      :float    => 5,
+    }
+
     def self.wire_for(type)
-      case type
-      when Class
-        if encodable?(type)
-          2
-        else
-          raise UnknownType, type
-        end
-      when :int32, :uint32, :sint32, :int64, :uint64, :sint64, :bool, Module
-        0
-      when :fixed64, :sfixed64, :double
-        1
-      when :string, :bytes
+      wire = WIRES[type]
+
+      if wire
+        wire
+      elsif Class === type && encodable?(type)
         2
-      when :fixed32, :sfixed32, :float
-        5
+      elsif Module === type
+        0
       else
         raise UnknownType, type
       end


### PR DESCRIPTION
Small improvement I found after using ruby-prof. case statements are usually performance killers in ruby, so better to avoid them.

Before (bench/simple.rb):

```
                       user     system      total        real
object creation    0.020000   0.000000   0.020000 (  0.015672)
message creation   0.490000   0.000000   0.490000 (  0.492956)
message encoding   2.950000   0.000000   2.950000 (  2.946238)
message decoding   4.110000   0.000000   4.110000 (  4.106664)
```

After:

```
                       user     system      total        real
object creation    0.010000   0.000000   0.010000 (  0.015033)
message creation   0.510000   0.000000   0.510000 (  0.507569)
message encoding   2.800000   0.000000   2.800000 (  2.798945)
message decoding   3.850000   0.000000   3.850000 (  3.848129)
```
