### PR TITLE
Test that encoding an unknown field fails silently

### DIFF
--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -259,7 +259,7 @@ class MessageTest < Test::Unit::TestCase
   end
 
   def test_encode_unknown_field
-    msg = SimpleMessage.new mystery_field: 'asdf'
+    msg = SimpleMessage.new :mystery_field => 'asdf'
     assert_nothing_raised do
       msg.encode.to_s
     end


### PR DESCRIPTION
This doesn't change any behavior, just describes it.
