### PR TITLE
Speedup encodable check

### DIFF
--- a/lib/beefcake/buffer/base.rb
+++ b/lib/beefcake/buffer/base.rb
@@ -46,8 +46,7 @@ module Beefcake
 
     def self.encodable?(type)
       return false if ! type.is_a?(Class)
-      pims = type.public_instance_methods
-      pims.include?(:encode) || pims.include?("encode")
+      type.public_method_defined?(:encode)
     end
 
     attr_reader :buf


### PR DESCRIPTION
This is showing up as the most expensive line in my CPU profile of the Riak client. Pretty simple fix, appears compatible with all Ruby versions.

Timing in milliseconds on 10,000 iterations:

``` ruby
#public_method_defined?
{:real=>0.944, :cpu=>1, :idle=>-0.05600000000000005}

#public_instance_methods.include?
{:real=>1202.375, :cpu=>1194, :idle=>8.375}
```

https://gist.github.com/eac/5011b6c53578c1d20773
