### PR TITLE
Use the package name for namespacing

### DIFF
--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -142,8 +142,10 @@ module Beefcake
 
     def self.compile(ns, req)
       file = req.proto_file.map do |file|
+        package_ns = ns + (file.package || "").split(/\W+/).map(&:capitalize)
+
         g = new(StringIO.new)
-        g.compile(ns, file)
+        g.compile(package_ns, file)
 
         g.c.rewind
         CodeGeneratorResponse::File.new(

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -35,6 +35,12 @@ class GeneratorTest < Minitest::Test
     assert_match(/module Top\s*\n\s*module Bottom/m, @res.file.first.content)
   end
 
+  def test_generate_package_namespace
+    @req.proto_file.first.package = "middle.bottom"
+    @res = Beefcake::Generator.compile(["Top"], @req)
+    assert_match(/module Top\s*\n\s*module Middle\s*\n\s*module Bottom/m, @res.file.first.content)
+  end
+
   # Covers the regression of encoding a CodeGeneratorResponse under 1.9.2-p136 raising
   # Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and US-ASCII
   def test_encode_decode_generated_response


### PR DESCRIPTION
This adds the ability to use the package name in a .proto file for
namespacing while preserving the option for global namespacing.