### PR TITLE
Nested messages are incorrectly converted to a hash

### DIFF
--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -326,19 +326,22 @@ module Beefcake
 
     def to_hash
       __beefcake_fields__.values.inject({}) do |h, fld|
-        if v = self[fld.name]
-          h[fld.name] =
-              case
-                # A nested protobuf message, so let's call its 'to_hash' method.
-                when v.respond_to?(:to_hash) ; v.to_hash
-                when v.is_a?(Array)
-                  # There can be two field types stored in array.
-                  # Primitive type or nested another protobuf message.
-                  # The later one has got a 'to_hash' method.
-                  h[fld.name] = v.map { |i| i.respond_to?(:to_hash) ? i.to_hash : i }
-                else ; v
-              end
-        end
+        v = self[fld.name]
+        next h if v.nil?
+
+        h[fld.name] =
+          case
+          when v.respond_to?(:to_hash)
+            # A nested protobuf message, so let's call its 'to_hash' method.
+            v.to_hash
+          when v.is_a?(Array)
+            # There can be two field types stored in array.
+            # Primitive type or nested another protobuf message.
+            # The later one has got a 'to_hash' method.
+            v.map { |i| i.respond_to?(:to_hash) ? i.to_hash : i }
+          else
+            v
+          end
         h
       end
     end

--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -264,16 +264,24 @@ module Beefcake
           next
         end
 
-        self[fld.name] = fld.is_protobuf? ?
-          if not fld.repeated?
-            fld.same_type?(attrs[fld.name]) ?
-              attrs[fld.name] : fld.type.new(attrs[fld.name])
-          else
-            attrs[fld.name].map do |i|
-              fld.same_type?(i) ? i : fld.type.new(i)
-            end
+        unless fld.is_protobuf?
+          self[fld.name] = attrs[fld.name]
+          next
+        end
+
+        if fld.repeated?
+          self[fld.name] = attrs[fld.name].map do |i|
+            fld.same_type?(i) ? i : fld.type.new(i)
           end
-        : attrs[fld.name]
+          next
+        end
+
+        if fld.same_type? attrs[fld.name]
+          self[fld.name] = attrs[fld.name]
+          next
+        end
+
+        self[fld.name] = fld.type.new(attrs[fld.name])
       end
       self
     end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -107,62 +107,62 @@ class FieldTest < Minitest::Test
 
   def test_required?
     f = FIELD.new :required, :field1, :string, 1
-    assert_true  f.required?
-    assert_false f.optional?
-    assert_false f.repeated?
+    assert f.required?
+    refute f.optional?
+    refute f.repeated?
 
     f = FIELD.new :optional, :field1, :int32, 1
-    assert_false f.required?
+    refute f.required?
 
     f = FIELD.new :repeated, :field1, :int32, 1
-    assert_false f.required?
+    refute f.required?
   end
 
   def test_optional?
     f = FIELD.new :optional, :field1, :string, 1
-    assert_true  f.optional?
-    assert_false f.required?
-    assert_false f.repeated?
+    assert f.optional?
+    refute f.required?
+    refute f.repeated?
 
     f = FIELD.new :required, :field1, :int32, 1
-    assert_false f.optional?
+    refute f.optional?
 
     f = FIELD.new :repeated, :field1, :int32, 1
-    assert_false f.optional?
+    refute f.optional?
   end
 
   def test_repeated?
     f = FIELD.new :repeated, :field1, :string, 1
-    assert_true  f.repeated?
-    assert_false f.required?
-    assert_false f.optional?
+    assert f.repeated?
+    refute f.required?
+    refute f.optional?
 
     f = FIELD.new :optional, :field1, :int32, 1
-    assert_false f.repeated?
+    refute f.repeated?
 
     f = FIELD.new :required, :field1, :int32, 1
-    assert_false f.optional?
+    refute f.optional?
   end
 
   def test_same_type
     f = FIELD.new(:required, :field1, :int32, 1)
-    assert_true  f.same_type?(:int32)
-    assert_false f.same_type?(:int64)
-    assert_false f.same_type?(SimpleMessage)
+    assert f.same_type?(:int32)
+    refute f.same_type?(:int64)
+    refute f.same_type?(SimpleMessage)
 
     f = FIELD.new(:required, :field1, SimpleMessage, 1)
-    assert_true  f.same_type?(SimpleMessage)
-    assert_false f.same_type?(:int32)
-    assert_false f.same_type?(:string)
-    assert_false f.same_type?(NumericsMessage)
+    assert f.same_type?(SimpleMessage)
+    refute f.same_type?(:int32)
+    refute f.same_type?(:string)
+    refute f.same_type?(NumericsMessage)
   end
 
   def test_is_protobuf?
     f = FIELD.new(:required, :field1, SimpleMessage, 1)
-    assert_true f.is_protobuf?
+    assert f.is_protobuf?
 
     f = FIELD.new(:required, :field1, :string, 1)
-    assert_false f.is_protobuf?
+    refute f.is_protobuf?
   end
 end
 


### PR DESCRIPTION
This supersedes #18 , and can be merged safely in to a future 1.1.0.