### PR TITLE
Allow use of hashes to assign a single element of a repeated field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ rvm:
   - rbx-2.2.7
   - ruby-head
   - jruby-head
-  - rbx-head
 matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: rbx-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.1.1
-  - 2.1.2
+  - 2.1.5
+  - 2.2.0
   - jruby-19mode
+  - rbx-2.2.7
+  - ruby-head
+  - jruby-head
+  - rbx-head
+matrix:
+  allow_failures:
+    - rvm: jruby-head
+    - rvm: ruby-head
+    - rvm: rbx-head

--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -276,6 +276,11 @@ module Beefcake
           next
         end
 
+        if fld.repeated? && attribute.is_a?(fld.type)
+          self[fld.name] = attribute
+          next
+        end
+
         if fld.repeated?
           self[fld.name] = attribute.map do |i|
             fld.same_type?(i) ? i : fld.type.new(i)

--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -277,7 +277,7 @@ module Beefcake
         end
 
         if fld.repeated? && attribute.is_a?(fld.type)
-          self[fld.name] = attribute
+          self[fld.name] = [attribute]
           next
         end
 

--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -259,29 +259,36 @@ module Beefcake
     # @param [Hash] data to fill a protobuf message with.
     def assign(attrs)
       __beefcake_fields__.values.each do |fld|
-        if attrs[fld.name].nil?
+        attribute = attrs[fld.name]
+
+        if attribute.nil?
           self[fld.name] = nil
           next
         end
 
         unless fld.is_protobuf?
-          self[fld.name] = attrs[fld.name]
+          self[fld.name] = attribute
+          next
+        end
+
+        if fld.repeated? && attribute.is_a?(Hash)
+          self[fld.name] = fld.type.new(attribute)
           next
         end
 
         if fld.repeated?
-          self[fld.name] = attrs[fld.name].map do |i|
+          self[fld.name] = attribute.map do |i|
             fld.same_type?(i) ? i : fld.type.new(i)
           end
           next
         end
 
-        if fld.same_type? attrs[fld.name]
-          self[fld.name] = attrs[fld.name]
+        if fld.same_type? attribute
+          self[fld.name] = attribute
           next
         end
 
-        self[fld.name] = fld.type.new(attrs[fld.name])
+        self[fld.name] = fld.type.new(attribute)
       end
       self
     end

--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -197,7 +197,8 @@ module Beefcake
             end
           elsif fld.rule == :repeated
             val = buf.read(fld.type)
-            (o[fld.name] ||= []) << val
+            o[fld.name] ||= []
+            o[fld.name] << val
           else
             val = buf.read(fld.type)
             o[fld.name] = val

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -347,6 +347,11 @@ class MessageTest < Minitest::Test
     RepeatedNestedMessage.new before
   end
 
+  def test_repeated_with_scalar
+    inner = SimpleMessage.new(b: 'hello')
+    RepeatedNestedMessage.new simple: inner
+  end
+
   ## Decoding
   def test_decode_numerics
     msg = NumericsMessage.new({

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -342,6 +342,11 @@ class MessageTest < Minitest::Test
     msg.encode.to_s
   end
 
+  def test_repeated_with_hash
+    before = { simple: { b: 'hello' } }
+    RepeatedNestedMessage.new before
+  end
+
   ## Decoding
   def test_decode_numerics
     msg = NumericsMessage.new({


### PR DESCRIPTION
basho/riak-ruby-client uses this pattern quite a bit:

```ruby
class RpbModFun
  required :module, :bytes, 1
  required :function, :bytes, 2
end

class RpbCommitHook
  optional :modfun, RpbModFun, 1
  optional :name, :bytes, 2
end

class RpbBucketProps
  repeated :precommit, RpbCommitHook, 4
end

RpbBucketProps.new precommit: {modfun: {module: 'validate_json', function: 'validate'}}
```

The intended effect is to create an optional `RpbModFun` message inside a repeated `RpbCommitHook` message inside a `RpbBucketProps` message.

After #60, this behavior changed. This PR tests and fixes this behavior.