### PR TITLE
Bk gh63 persist object identities

### DIFF
--- a/lib/beefcake.rb
+++ b/lib/beefcake.rb
@@ -38,6 +38,10 @@ module Beefcake
         type == obj
       end
 
+      def matches_type?(obj)
+        obj.is_a? type
+      end
+
       def is_protobuf?
         type.is_a?(Class) and type.include?(Beefcake::Message)
       end
@@ -284,12 +288,12 @@ module Beefcake
 
         if fld.repeated?
           self[fld.name] = attribute.map do |i|
-            fld.same_type?(i) ? i : fld.type.new(i)
+            fld.matches_type?(i) ? i : fld.type.new(i)
           end
           next
         end
 
-        if fld.same_type? attribute
+        if fld.matches_type? attribute
           self[fld.name] = attribute
           next
         end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -471,6 +471,13 @@ class MessageTest < Minitest::Test
     refute_equal :symbol, d
   end
 
+  def test_object_identity
+    inside = [SimpleMessage.new(a: 12345)]
+    outside = RepeatedNestedMessage.new simple: inside
+
+    assert_equal outside.simple.first.object_id, inside.first.object_id
+  end
+
   def test_inspect
     msg = SimpleMessage.new :a => 1
     assert_equal "<SimpleMessage a: 1>", msg.inspect


### PR DESCRIPTION
Issue #63 with Riemann was caused by `Message#assign` incorrectly checking to see if repeated nested messages passed to constructors are equal to the type of the field, instead of instances of the type of the field.