### PR TITLE
do not alter a string's encoding when appending to a message

### DIFF
--- a/lib/beefcake/buffer/encode.rb
+++ b/lib/beefcake/buffer/encode.rb
@@ -106,7 +106,7 @@ module Beefcake
 
     def append_string(s)
       actual_string = thaw_string s
-      encoded = actual_string.force_encoding 'binary'
+      encoded = actual_string.dup.force_encoding 'binary'
       append_uint64(encoded.length)
       self << encoded
     end

--- a/test/buffer_encode_test.rb
+++ b/test/buffer_encode_test.rb
@@ -24,6 +24,14 @@ class BufferEncodeTest < Minitest::Test
     assert_equal "\007testing", @buf.to_s
   end
 
+  def test_append_string_does_not_change_encoding
+    subject = "testing".force_encoding('UTF-8')
+    assert_equal 'UTF-8', subject.encoding.name
+
+    @buf.append_string(subject)
+    assert_equal 'UTF-8', subject.encoding.name
+  end
+
   def test_append_fixed32
     @buf.append_fixed32(1)
     assert_equal "\001\0\0\0", @buf.to_s


### PR DESCRIPTION
fixes protobuf-ruby/beefcake#69

@bkerley @jwarchol look ok?