### PR TITLE
capitalize class names for nested messages

### DIFF
--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -174,7 +174,7 @@ module Beefcake
 
     def define!(mt)
       puts
-      puts "class #{mt.name}"
+      puts "class #{klass_name(mt.name)}"
 
       indent do
         puts "include Beefcake::Message"
@@ -194,7 +194,7 @@ module Beefcake
 
     def message!(pkg, mt)
       puts
-      puts "class #{mt.name}"
+      puts "class #{klass_name(mt.name)}"
 
       indent do
         ## Generate Types
@@ -245,7 +245,7 @@ module Beefcake
       end
 
       # Finally, generate the declaration
-      out = "%s %s, %s, %d" % [label, name, type, f.number]
+      out = "%s %s, %s, %d" % [label, name, type_name(type), f.number]
 
       if f.default_value
         v = case f.type
@@ -309,5 +309,23 @@ module Beefcake
       end
     end
 
+    private
+
+    def type_name(name)
+      name = name.dup
+
+      pars = name.split('::').map do |klass|
+        klass[0] = klass[0].capitalize
+        klass
+      end
+
+      pars.join('::')
+    end
+
+    def klass_name(name)
+      name = name.dup
+      name[0] = name[0].capitalize
+      name
+    end
   end
 end


### PR DESCRIPTION
Messages like

```
message CSVCMsg_ClassInfo {
    message class_t {
        optional int32 class_id = 1;
    }

    optional bool create_on_client = 1;
        repeated .CSVCMsg_ClassInfo.class_t classes = 2;
}
```

Would have a class generated into something like.

```
class CSVCMsg_ClassInfo
  class class_t
  end

 repeated CSVCMsg_ClassInfo::class_t, ..., ...

end

```

Ruby does not like the lower case class names, this fixes that issue. Let me know what you think
