### PR TITLE
Ensure that referenced classes contain full namespace.

### DIFF
--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -139,7 +139,6 @@ module Beefcake
     L = CodeGeneratorRequest::FieldDescriptorProto::Label
     T = CodeGeneratorRequest::FieldDescriptorProto::Type
 
-
     def self.compile(ns, req)
       file = req.proto_file.map do |file|
         g = new(StringIO.new)
@@ -192,19 +191,19 @@ module Beefcake
       puts "end"
     end
 
-    def message!(pkg, mt)
+    def message!(pkg, mt, ns)
       puts
       puts "class #{mt.name}"
 
       indent do
         ## Generate Types
         Array(mt.nested_type).each do |nt|
-          message!(pkg, nt)
+          message!(pkg, nt, ns)
         end
 
         ## Generate Fields
         Array(mt.field).each do |f|
-          field!(pkg, f)
+          field!(pkg, f, ns)
         end
       end
 
@@ -222,7 +221,7 @@ module Beefcake
       puts "end"
     end
 
-    def field!(pkg, f)
+    def field!(pkg, f, ns)
       # Turn the label into Ruby
       label = name_for(f, L, f.label)
 
@@ -234,19 +233,13 @@ module Beefcake
         # We have a type_name so we will use it after converting to a
         # Ruby friendly version
         t = f.type_name
-        if pkg
-          t = t.gsub(pkg, "") # Remove the leading package name
-        end
-        t = t.gsub(/^\.*/, "")       # Remove leading `.`s
-
-        t.gsub(".", "::")  # Convert to Ruby namespacing syntax
+        namespaced_type(t, pkg, ns)
       else
         ":#{name_for(f, T, f.type)}"
       end
 
       # Finally, generate the declaration
       out = "%s %s, %s, %d" % [label, name, type, f.number]
-
       if f.default_value
         v = case f.type
         when T::TYPE_ENUM
@@ -261,6 +254,31 @@ module Beefcake
       end
 
       puts out
+    end
+
+    # Generates a correctly namespaced ruby class name
+    # Removes pkg from type_pcs or from namespace
+    # Removes from type_pcs when infered type is same as pkg
+    # Removes from namespace when decendent is same as pkg
+    #
+    # @param type [String] A field type name
+    # @param pkg [String] The package name from the protobuf
+    # @param ns [String] The user provided namespace
+    #
+    # @return [String] A correctly namespaced ruby class name
+    def namespaced_type(type, pkg, ns)
+      wires = Buffer::WIRES.keys
+      type_key = type.gsub(/^:/, '').to_sym
+      if wires.include?(type_key)
+        type
+      type_pcs = type.split('.').reject!(&:empty?)
+      namespace = ns.clone
+          if type_pcs.first == pkg
+        type_pcs.shift
+      elsif namespace.last.downcase == pkg.downcase
+        namespace.pop
+      end
+      namespace.push(*type_pcs).join('::')
     end
 
     # Determines the name for a
@@ -284,7 +302,7 @@ module Beefcake
         end
 
         file.message_type.each do |mt|
-          message!(file.package, mt)
+          message!(file.package, mt, ns)
         end
       end
     end

--- a/lib/beefcake/generator.rb
+++ b/lib/beefcake/generator.rb
@@ -267,18 +267,17 @@ module Beefcake
     #
     # @return [String] A correctly namespaced ruby class name
     def namespaced_type(type, pkg, ns)
-      wires = Buffer::WIRES.keys
       type_key = type.gsub(/^:/, '').to_sym
-      if wires.include?(type_key)
-        type
+      return type if Buffer::WIRES.keys.include?(type_key)
+
       type_pcs = type.split('.').reject!(&:empty?)
       namespace = ns.clone
-          if type_pcs.first == pkg
+      if type_pcs.first == pkg
         type_pcs.shift
-      elsif namespace.last.downcase == pkg.downcase
+      elsif namespace.last.casecmp(pkg)
         namespace.pop
       end
-      namespace.push(*type_pcs).join('::')
+      namespace.concat(type_pcs).join('::')
     end
 
     # Determines the name for a

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -33,6 +33,31 @@ class GeneratorTest < Minitest::Test
     assert_match(/module Top\s*\n\s*module Bottom/m, @res.file.first.content)
   end
 
+  def test_generate_top_namespaced_class_name
+    @res = Beefcake::Generator.compile(['Top'], @req)
+    assert_equal(CodeGeneratorResponse, @res.class)
+    assert_match(
+      / Top\:\:Person\:\:PhoneType/,
+      @res.file.first.content
+    )
+    refute_match(
+      / Person\:\:PhoneType/,
+      @res.file.first.content
+    )
+  end
+
+  def test_generate_two_level_namespaced_class_name
+    @res = Beefcake::Generator.compile(['Top', 'Gun'], @req)
+    assert_equal(CodeGeneratorResponse, @res.class)
+    assert_match(
+      / Top\:\:Gun\:\:Person\:\:PhoneType/,
+      @res.file.first.content
+    )
+    refute_match(
+      / Person\:\:PhoneType/,
+      @res.file.first.content
+    )
+  end
   # Covers the regression of encoding a CodeGeneratorResponse under 1.9.2-p136 raising
   # Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and US-ASCII
   def test_encode_decode_generated_response


### PR DESCRIPTION
This patch adds a complete namespace to classes referenced by the generated Protobuf ruby classes.

eg. `Protobuf::Test::Beta` vs `Beta`

Referencing the class with its full namespace is needed when using autoloading and the implementers code contains a pre-existing class with the same name as the class referenced within the protobuf.

Here's a very basic example.

``` ruby
# app/models/protobuf/test/alpha.rb
require "beefcake"

module Protobuf
  module Test
    class Alpha
      include Beefcake::Message
    end

    class Alpha
      required :id, :int32, 1
      optional :beta, Beta, 2
    end
  end
end

```

``` ruby
# app/models/protobuf/test/beta.rb
require "beefcake"

module Protobuf
  module Test

    class Beta
      include Beefcake::Message
    end

    class Beta
      required :id, :int32, 1
    end
  end
end
```

``` ruby
# app/models/beta.rb
class Beta
 # no op
end
```

If the Protobuf references another Protobuf class which **has the same name as an existing class**, load order takes precedence. Even when the existing class is in another namespace. This leads to the Protobuf referencing `Beta` vs `Protobuf::Test::Beta`

```
2.3.1 :001 > Beta
 => Beta
2.3.1 :002 > Protobuf::Test::Alpha.fields
 => {1=>#<struct Beefcake::Message::Field rule=:required, name=:id, type=:int32, fn=1, opts={}>, 2=>#<struct Beefcake::Message::Field rule=:optional, name=:beta, type=Beta, fn=2, opts={}>}
```

When other classes are **not** loaded first, the Protobuf references the correct class.

```
2.3.1 :001 > Protobuf::Test::Alpha.fields
 => {1=>#<struct Beefcake::Message::Field rule=:required, name=:id, type=:int32, fn=1, opts={}>, 2=>#<struct Beefcake::Message::Field rule=:optional, name=:beta, type=Protobuf::Test::Beta, fn=2, opts={}>}
```
